### PR TITLE
WS全体/チャンネル毎に各ユーザーが何回発言したかを表示

### DIFF
--- a/app/controllers/channel_users_controller.rb
+++ b/app/controllers/channel_users_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class ChannelUsersController < ApplicationController
+  def index
+    channel_id = channel_users_params.to_i
+    channel_users = ChannelUser.includes(:user).where(channel_id: channel_id).order(messages_count: 'DESC')
+    render json: channel_users.to_json(include: :user)
+  end
+
+  private
+
+  def channel_users_params
+    params.require(:channel_id)
+  end
+end

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -4,7 +4,7 @@ class ChannelsController < ApplicationController
   # GET /channels
   # GET /channels.json
   def index
-    @channels = Channel.all
+    @channels = Channel.all.order(messages_count: 'DESC')
     render json: @channels
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   # GET /users.json
   def index
     @users = User.all
+    render json: @users
   end
 
   # GET /users/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   # GET /users
   # GET /users.json
   def index
-    @users = User.all
+    @users = User.all.order(messages_count: 'DESC')
     render json: @users
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,5 +4,6 @@ class Message < ApplicationRecord
   delegate :user, to: :channel_user
   has_many :reactions
   has_many :emojis, through: :reactions
+  counter_culture :channel_user, column_name: 'messages_count'
   counter_culture %i[channel_user channel], column_name: 'messages_count'
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,5 +5,6 @@ class Message < ApplicationRecord
   has_many :reactions
   has_many :emojis, through: :reactions
   counter_culture :channel_user, column_name: 'messages_count'
+  counter_culture %i[channel_user user], column_name: 'messages_count'
   counter_culture %i[channel_user channel], column_name: 'messages_count'
 end

--- a/client/src/pages/channel/show.js
+++ b/client/src/pages/channel/show.js
@@ -22,6 +22,7 @@ export default class ChannelShow extends React.Component {
       channel: [],
       groupdate: {},
       rankSortedEmojis: [],
+      rankSortedUsers: [],
       channel_id: props.match.params.id
     };
   };
@@ -56,6 +57,15 @@ export default class ChannelShow extends React.Component {
         const data = results.data;
         this.setState({
           rankSortedEmojis: data
+        });
+      });
+
+    ApiClient
+      .get(`/channels/${this.state.channel_id}/users`)
+      .then(results => {
+        const data = results.data;
+        this.setState({
+          rankSortedUsers: data
         });
       });
   }
@@ -104,6 +114,31 @@ export default class ChannelShow extends React.Component {
               data={this.state.groupdate.data}
               labels={this.state.groupdate.labels}/>
           </Typography>
+          <Typography variant='h6'>発言者ランキング</Typography>
+          <Paper className={classes.root}>
+            <Table className={classes.table}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>ranking</TableCell>
+                  <TableCell>count</TableCell>
+                  <TableCell>image</TableCell>
+                  <TableCell>名前</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {this.state.rankSortedUsers.slice(0, ranking_max).map((row, i) => (
+                  <TableRow key={row.user.id}>
+                    <TableCell component="th" scope="row">{i + 1}</TableCell>
+                    <TableCell component="th" scope="row">{row.messages_count}</TableCell>
+                    <TableCell component="th" scope="row">
+                      <img src={row.user.profile_image} alt="" width="32" height="32" border=""/>
+                    </TableCell>
+                    <TableCell component="th" scope="row">{row.user.real_name}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Paper>
         </div>
       </main>
     );

--- a/client/src/pages/user/components/tables/UserPaginationTable.js
+++ b/client/src/pages/user/components/tables/UserPaginationTable.js
@@ -75,6 +75,7 @@ class UserPaginationTable extends React.Component {
                 <TableCell>名前</TableCell>
                 <TableCell>本名</TableCell>
                 <TableCell>Email</TableCell>
+                <TableCell>発言数</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -91,6 +92,9 @@ class UserPaginationTable extends React.Component {
                   </TableCell>
                   <TableCell component="th" scope="row">
                     {row.email}
+                  </TableCell>
+                  <TableCell component="th" scope="row">
+                    {row.messages_count}
                   </TableCell>
                 </TableRow>
               ))}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :channels do
     get 'message_groupdate', to: 'message_groupdates#index'
     get 'channel_emoji', to: 'channel_emojis#index'
+    get 'users', to: 'channel_users#index'
   end
   get 'message_groupdate', to: 'message_groupdates#index'
   resources :users

--- a/db/migrate/20190527060733_add_messages_count_to_channel_users.rb
+++ b/db/migrate/20190527060733_add_messages_count_to_channel_users.rb
@@ -1,0 +1,9 @@
+class AddMessagesCountToChannelUsers < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :channel_users, :messages_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :channel_users, :messages_count
+  end
+end

--- a/db/migrate/20190527072030_add_messages_count_to_users.rb
+++ b/db/migrate/20190527072030_add_messages_count_to_users.rb
@@ -1,0 +1,9 @@
+class AddMessagesCountToUsers < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :users, :messages_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :users, :messages_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_24_060116) do
+ActiveRecord::Schema.define(version: 2019_05_27_060733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_05_24_060116) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "joined", default: false, null: false
+    t.integer "messages_count", default: 0, null: false
     t.index ["channel_id"], name: "index_channel_users_on_channel_id"
     t.index ["user_id"], name: "index_channel_users_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_27_060733) do
+ActiveRecord::Schema.define(version: 2019_05_27_072030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2019_05_27_060733) do
     t.boolean "is_bot", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "messages_count", default: 0, null: false
     t.index ["id"], name: "index_users_on_id", unique: true
   end
 


### PR DESCRIPTION
## 概要
WS全体/チャンネル毎に各ユーザーが何回発言したかを表示

## 詳細（主に技術的変更点）
- チャンネル毎のユーザー一覧を取得するコントローラー作成
- User, ChannelモデルにMessage数を保持するカラム追加
- SlackAPIからThreadへの返信を取得できるように追加でAPIを叩く

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
- slackからデータを持ってくる方法
  - `$ export SLACK_API_TOKEN='hogehoge'`
  - `$ bin/rake 'pull_data:all[14]'`

## 保留した項目・TODOリスト
\- 
## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
\- 